### PR TITLE
without -r can't install requirements

### DIFF
--- a/projects/AudioBook/README.md
+++ b/projects/AudioBook/README.md
@@ -1,0 +1,14 @@
+# AudioBook
+
+### Description
+This application will make an mp3 based on you pdf file.
+
+### Instal the requirements
+```
+pip install gtts
+pip install PyPDF2
+```
+### Dun the application
+```
+python Audio-book.py
+```

--- a/projects/Todo_app/Readme.md
+++ b/projects/Todo_app/Readme.md
@@ -7,6 +7,6 @@
 # To run app
 - Create virtual Environment
 - Install requirements
-`pip install requirements.txt`
+`pip install -r requirements.txt`
 - run app
 `py app.py`


### PR DESCRIPTION
with pip install requirements.txt i have this error
ERROR: Could not find a version that satisfies the requirement requirements.txt (from versions: none)
ERROR: No matching distribution found for requirements.txt

to solve this I added the -r option

-r, --requirement <file>    Install from the given requirements file. This option can be used multiple times.
